### PR TITLE
Improve chat history

### DIFF
--- a/backend/LLMService.py
+++ b/backend/LLMService.py
@@ -276,7 +276,7 @@ class LLMService:
                                                ))
 
         if response and response.text:
-            chat_history.store_history(user_id, message, response.text, system=True)
+            chat_history.store_history(user_id, "Create a personalized 7-day workout schedule.", response.text, system=True)
             chat_history.store_plan(user_id, "workout_plan", response.text)
 
             return {"response": response.text, "progress": await user_stats.update_stat(user_id, "workout_plans")}

--- a/backend/chat_history.py
+++ b/backend/chat_history.py
@@ -119,7 +119,10 @@ async def get_plan(user_id: str, plan: Literal["meal_plan", "workout_plan"]):
 
     if not document:
         return None
-
+    
+    if plan == "meal_plan":
+        return json.dumps(document.get(plan, None))
+    
     return document.get(plan, None)
 
 

--- a/backend/routes/login.py
+++ b/backend/routes/login.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Security
 from fastapi_jwt import JwtAuthorizationCredentials
 from starlette import status
 
+import chat_history
 import database_connection
 from auth_service import AuthService
 from models.login_model import UserLogin
@@ -54,13 +55,14 @@ async def login(user_info: UserLogin):
 
 
 @router.post("/logout")  # with refresh_token
-def refresh(credentials: JwtAuthorizationCredentials = Security(AuthService.get_refresh_security())):
+async def logout(credentials: JwtAuthorizationCredentials = Security(AuthService.get_refresh_security())):
     AuthService.set_refresh_token_expired(credentials.jti)  # access_token will expire within 15 minutes
+    await chat_history.close(credentials["user_id"])
     return {}
 
 
 @router.post("/refresh")  # with refresh_token
-def refresh(credentials: JwtAuthorizationCredentials = Security(AuthService.get_refresh_security())):
+async def refresh(credentials: JwtAuthorizationCredentials = Security(AuthService.get_refresh_security())):
     if AuthService.is_refresh_token_expired(credentials.jti):  # or token created < last password change
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Login expired")
 


### PR DESCRIPTION
Handle chat history manually instead of using chat session API
This allows us to
- skip saving rag prompts as part of the chat history to potentially improve AI's performance in long chats
- save meal & workout plans as part of the chat history for AI to see them without needing to alter the session manually
- use chat history without database reads